### PR TITLE
【サーバサイド】商品詳細表示（画像以外）

### DIFF
--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -96,7 +96,7 @@
             background-color: white;
             padding: 10px 10px;
             &:hover{
-              background-color: silver;
+              background-color: #EEEEEE;
             }
           }
         }
@@ -111,7 +111,7 @@
             background-color: white;
             padding: 10px 10px;
             &:hover{
-              background-color: silver;
+              background-color: #EEEEEE;
             }
           }
         }

--- a/app/assets/stylesheets/items/items.scss
+++ b/app/assets/stylesheets/items/items.scss
@@ -30,11 +30,13 @@
     &__underimage{
       line-height: 0;
       background: #fafafa;
+      display: inline-block;
       &__sub{
         width: 60px;
         height: 60px;
         max-height: none;
         float: left;
+        cursor: pointer;
       }
     }
     &__table{

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,7 +5,10 @@ class ItemsController < ApplicationController
   end
 
   def show
-
+    @item = Item.find(params[:id])
+    @sellUser = User.find(@item.user_id)
+    @itemBrand = Brand.find(@item.brand_id)
+    @itemCategory = Category.find(@item.category_id)
   end
 
 end

--- a/app/models/brand.rb
+++ b/app/models/brand.rb
@@ -1,3 +1,10 @@
-class Brand < ApplicationRecord
-  has_many :items
+class Brand < ActiveHash::Base
+  self.data = [
+      {id: 1, name: "シャネル"},
+      {id: 2, name: "ナイキ"},
+      {id: 3, name: "ルイヴィトン"},
+      {id: 4, name: "シュプリーム"},
+      {id: 5, name: "アディダス"},
+      {id: 6, name: "ブランド一覧"}
+  ]
 end

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -3,11 +3,15 @@
 .main.clearfix
   .shosaimain.clearfix
     .shosaimain__item.clearfix
-      ="ゲーム１２本詰め合わせセット"
+      = @item.name
     .shosaimain__iteminfo.clearfix
       .shosaimain__iteminfo__image
         = image_tag '45019.png', height: "300", width: "300"
         .shosaimain__iteminfo__underimage
+          .shosaimain__iteminfo__underimage__sub
+            = image_tag '45019.png', height: "60", width: "60"
+          .shosaimain__iteminfo__underimage__sub
+            = image_tag '45019.png', height: "60", width: "60"
           .shosaimain__iteminfo__underimage__sub
             = image_tag '45019.png', height: "60", width: "60"
           .shosaimain__iteminfo__underimage__sub
@@ -23,7 +27,7 @@
               %th 出品者
               %td
                 = link_to '' ,class:"text-blue" do 
-                  = "田中"
+                  = @sellUser.nickname
                 %div
                   = fa_icon '', class: 'icon fa fa-smile-o color-good'
                   = 55
@@ -34,34 +38,47 @@
             %tr
               %th カテゴリー
               %td
-                = link_to '' ,class:"text-blue" do 
-                  = "ゲーム"
+                %div
+                  = link_to '' ,class:"text-blue" do 
+                    = @itemCategory.category_left_name
+                %div
+                  = link_to '' ,class:"text-blue" do
+                    = fa_icon '', class: 'icon fa fa-chevron-right text-blue'
+                    = @itemCategory.category_center_name
+                %div
+                  = link_to '' ,class:"text-blue" do
+                    = fa_icon '', class: 'icon fa fa-chevron-right text-blue'
+                    = @itemCategory.category_right_name
             %tr
               %th ブランド
               %td
                 = link_to '' ,class:"text-blue" do 
-                  = "任天堂"
+                  = @itemBrand.name
             %tr
               %th 商品の状態
-              %td 目立った傷や汚れなし
+              %td 
+                = Condition.find(@item.condition_id).name
             %tr
               %th 配送料の負担
-              %td 送料込み(出品者負担)
+              %td
+                = DeliveryCharge.find(@item.delivery_charge_id).name
             %tr
               %th 発送の方法
-              %td らくらくメルカリ便
+              %td 
+                = @item.shipping_method
             %tr
               %th 配送元地域
               %td 
-                = link_to '' ,class:"text-blue" do 
-                  = "愛知県"
+                = ShippingPrefecture.find(@item.shipping_prefecture_id).name
             %tr
               %th 発送日の目安
-              %td 4~7日で発送
+              %td 
+                = ShippingDate.find(@item.shipping_date_id).name
     %div
     .shosaimain__pricearea
       .shosaimain__pricearea__price
-        = "¥2,000"
+        = '¥'
+        = @item.price.to_s(:delimited)
         %span.shosaimain__pricearea__zekomi
           = "(税込)" 
           %span.shosaimain__pricearea__soryo
@@ -69,11 +86,7 @@
     .shosaimain__buybutton
       ="購入画面に進む"
     .shosaimain__honbun
-      %p 友人からの頂き物です。特に気になる汚れはありません。
-      %p
-        =""
-      %p 写真で判断をお願いします。
-      %p 中古品である事を理解の上購入をお願い致します。
+      = @item.description
     .shosaimain__kabu
       .shosaimain__kabu__left
         %button.shosaimain__kabu__left__line

--- a/app/views/tops/_header.html.haml
+++ b/app/views/tops/_header.html.haml
@@ -33,7 +33,6 @@
                 = link_to '' do
                   .left_contents__category--area3--list{data: {right: "#{f3.category_left_id}#{f3.category_center_id}#{f3.category_right_id}"}}
                     = f3.category_right_name
-
     %li.left_contents__brand
       = link_to '' do
         .left_contents__brand--icon

--- a/app/views/tops/index.html.haml
+++ b/app/views/tops/index.html.haml
@@ -29,7 +29,7 @@
     %ul.item_list
       /最終的にeachでまとめることになる
       %li.item_list__a
-        = link_to item_path(0) do
+        = link_to item_path(1) do
           .item_list__a--image
             /仮置き
             = image_tag '45019.png', height: "190", width: "180"


### PR DESCRIPTION
# What
商品詳細表示のサーバーサイドの実装

# Why
出品データを正しく表示させたい。
※出品画面が途中のため暫定で実装（画像表示はあとで行う）
　一旦現在の状態をコミットしたいので、現状をレビューお願いします。