### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/assets/stylesheets/items/items.scss
+++ b/app/assets/stylesheets/items/items.scss
@@ -176,3 +176,13 @@
     }
   }
 }
+.orlayout{
+  padding-top: 10px;
+  text-align: center;
+  top:50%;
+  font-size: 20px;
+}
+.colorlightgray{
+  background-color: lightgray !important;
+  color:black !important;
+}

--- a/app/assets/stylesheets/items/new.scss
+++ b/app/assets/stylesheets/items/new.scss
@@ -347,3 +347,7 @@ select{
     }
   }
 }
+.bottom_contents{
+  background-color: whitesmoke;
+  overflow: hidden;
+}

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -145,4 +145,5 @@
     .back_button
       = link_to root_path do
         %a{class: "font-white"}> もどる
-= render "devise/shared/registration_login_footer"
+.bottom_contents
+  = render "devise/shared/registration_login_footer"

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -76,8 +76,21 @@
           = "(税込)" 
           %span.shosaimain__pricearea__soryo
             = "送料込み"
-    .shosaimain__buybutton
-      ="購入画面に進む"
+    - if current_user.id != @item.seller_id
+      .shosaimain__buybutton
+        ="購入画面に進む"
+    - if current_user.id == @item.seller_id
+      = link_to edit_item_path(@item.id) do
+        .shosaimain__buybutton
+          ="変更する"
+      .orlayout
+        = "or"
+      .shosaimain__buybutton.colorlightgray
+        ="出品を一時停止する"
+      .shosaimain__buybutton.colorlightgray
+        = link_to 'この商品を削除する', item_path(@item.id), method: :delete
+      
+
     .shosaimain__honbun
       = @item.description
     .shosaimain__kabu

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,7 @@ Rails.application.routes.draw do
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root 'tops#index'
-  resources :items, only: [:new, :create]
+  resources :items, only: [:new, :create, :edit, :destroy]
   resources :mypage, only: [:index, :create, :edit, :update] do
     resources :identification, only: [:index]
     resources :card, only: [:index]


### PR DESCRIPTION
[what]
商品削除機能を実装した。
商品詳細ページから削除できるようにした。

[why]
商品出品を取りやめる等したい場合に必要となるため。